### PR TITLE
Fix remaining balance calculation in budget health report

### DIFF
--- a/tests/test_budget_health_totals.py
+++ b/tests/test_budget_health_totals.py
@@ -1,0 +1,20 @@
+import pytest
+
+from budget_health_analyzer import BudgetHealthAnalyzer
+
+
+def test_calculate_budget_totals_ignores_category_balances():
+    analyzer = BudgetHealthAnalyzer(budget_id="dummy")
+    analyzer._budget_data = {
+        "categories": [
+            {"deleted": False, "hidden": False, "budgeted": 100, "activity": -40, "balance": 60},
+            {"deleted": False, "hidden": False, "budgeted": 0, "activity": 20, "balance": 20},
+            {"deleted": False, "hidden": False, "budgeted": 0, "activity": 0, "balance": 1000},
+        ]
+    }
+
+    budgeted, spent, remaining = analyzer._calculate_budget_totals()
+
+    assert budgeted == 100
+    assert spent == 20  # Net spending 40 with a 20 refund
+    assert remaining == 80  # 100 budgeted - 20 spent


### PR DESCRIPTION
## Summary
- derive remaining budget from current month budgeted and activity instead of accumulated category balances
- use computed totals directly when returning metrics
- test that budget totals exclude carryover balances so remaining matches budgeted minus spent

## Testing
- `PYTHONPATH=. STAGING=true pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bef4b834648321a07126b5ecc2ad7c